### PR TITLE
Remove the leftover title line above the retirement notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-Contributing to [Apache Maven Stage Plugin](https://maven.apache.org/plugins/maven-stage-plugin/)
 RETIRED - [Apache Maven Verifier Plugin](https://maven.apache.org/plugins/maven-verifier-plugin/)
 =================================================================================================
 


### PR DESCRIPTION
Fixes the header left broken by the previous README commit. The old `Contributing to ...` line survived above the new title, so the rendered header ran the two together:

> Contributing to Apache Maven Stage Plugin RETIRED - Apache Maven Verifier Plugin

In this repository the stray line also named the wrong plugin — Stage rather than Verifier — because both READMEs were generated from the same template and the licence header was copied one line too far.

One line deleted; the rest of the file is unchanged.

<sub>Drafted with Claude — please verify</sub>