### PR TITLE
Drop the homepage and Jira autolink from .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -17,7 +17,6 @@
 # see https://s.apache.org/asfyaml
 github:
   description: "Apache Maven Verifier Plugin (RETIRED)"
-  homepage: https://maven.apache.org/plugins/maven-verifier-plugin/
   labels:
     - java
     - build-management
@@ -28,8 +27,6 @@ github:
     squash: true
     merge: false
     rebase: true
-  autolink_jira:
-    - MVERIFIER
   protected_branches:
     master: { }
   pull_requests:


### PR DESCRIPTION
Removes two `github:` entries that describe a plugin still under development.

| Key | Why |
|---|---|
| `homepage` | Points at a generated site that will never be regenerated — the vote resolved not to make a final release. |
| `autolink_jira` | Turns ticket references into links to a Jira project that INFRA-28233 asks to archive alongside this repository. |

**Neither removal changes anything on GitHub**, which is worth stating plainly so nobody expects it to. From `infrastructure-asfyaml`:

- `feature/github/metadata.py` — `if homepage and not self.noop("homepage")`. An absent key, or an empty string, is falsy and skipped; nothing ever calls `edit(homepage="")`. There is no way to clear the homepage through `.asf.yaml`.
- `feature/github/autolink.py` — only ever calls `create_autolink` for entries present in the file. There is no deletion path, so existing autolinks survive.

Clearing either on GitHub itself needs INFRA, and has been raised there rather than here.

`features.issues` is deliberately left enabled. `feature/github/features.py` passes `has_issues=features.get("issues", False)`, so dropping the key while keeping the `features` block would actively disable issues — hiding every report migrated out of Jira. An archived repository keeps its issues readable; one with the feature disabled does not.

Wants to merge before INFRA acts on INFRA-28233 — `.asf.yaml` stops being applied once the repository is read only.

<sub>Drafted with Claude — please verify</sub>