### PR TITLE
Do not link the README title to the plugin site

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-RETIRED - [Apache Maven Verifier Plugin](https://maven.apache.org/plugins/maven-verifier-plugin/)
-=================================================================================================
+RETIRED - Apache Maven Verifier Plugin
+======================================
 
 [![Apache License, Version 2.0, January 2004](https://img.shields.io/github/license/apache/maven.svg?label=License)][license]
 [![Maven Central](https://img.shields.io/maven-central/v/org.apache.maven.plugins/maven-verifier-plugin.svg?label=Maven%20Central)](https://search.maven.org/artifact/org.apache.maven.plugins/maven-verifier-plugin)


### PR DESCRIPTION
The title linked to https://maven.apache.org/plugins/maven-verifier-plugin/ . That site goes to the archive along with the plugin, so the link would rot inside a README nobody can edit once the repository is read only.

```
RETIRED - Apache Maven Verifier Plugin
======================================
```

The plugin name alone identifies it, and the mailing-list link further down still resolves — that page outlives any individual component.

Same change is folded into apache/maven-stage-plugin#77, which was still open. Wants to merge before INFRA acts on INFRA-28233.

<sub>Drafted with Claude — please verify</sub>