### PR TITLE
Point the homepage at the Maven site instead of the plugin site

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -17,6 +17,7 @@
 # see https://s.apache.org/asfyaml
 github:
   description: "Apache Maven Verifier Plugin (RETIRED)"
+  homepage: https://maven.apache.org/
   labels:
     - java
     - build-management


### PR DESCRIPTION
Follow-up to #70, which removed `homepage` outright. Setting it is better than dropping it.

The plugin site goes to the archive along with the plugin, so the repository "About" link would eventually resolve to nothing. Pointing it at https://maven.apache.org/ keeps a useful link and, unlike removal, actually takes effect: `feature/github/metadata.py` applies any truthy homepage, but skips an absent or empty one — so #70 stopped asserting the old URL without clearing what GitHub still stores.

This also makes the first half of my comment on INFRA-28233 unnecessary; only the autolink deletion still needs INFRA.

<sub>Drafted with Claude — please verify</sub>